### PR TITLE
Note we need to append `"Indexer"` to `rpc.modules` in `ckb.toml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,14 @@ filter = "info,ckb-script=debug"# instead of "info"
 # Other parameters...
 ```
 
-9. In the `ckb-miner.toml` file under the `[[miner.workers]]` section set:
+9. In the `ckb.toml` file under the `[rpc]` section set:
+Append `"Indexer"` to `modules`.
+```toml
+modules = ["Net", "Pool", "Miner", "Chain", "Stats", "Subscription", "Experiment", "Debug", "Indexer"]
+
+```
+
+10. In the `ckb-miner.toml` file under the `[[miner.workers]]` section set:
 
 ``` toml
 [[miner.workers]]
@@ -79,13 +86,13 @@ filter = "info,ckb-script=debug"# instead of "info"
 value = 200 # instead of 5000
 ```
 
-10. Activate the new spec for the first use by running the following command for a few seconds:
+11. Activate the new spec for the first use by running the following command for a few seconds:
 
 ``` bash
 ckb run --skip-spec-check --overwrite-spec
 ```
 
-11. In a new terminal start ckb node and miner:
+12. In a new terminal start ckb node and miner:
 
 ```bash
 (trap 'kill -INT 0' SIGINT; cd ~/ckb_dev/; ./ckb run --indexer & sleep 1 && ./ckb miner)


### PR DESCRIPTION
I try to follow the instructions on `README.md`, and I got this:
```bash
v1-interface on  master is 📦 v1.0.0 via  v18.16.1 took 3s
$ npm run start

> v1-interface@1.0.0 start
> ts-node index.ts

Initializing Config
✓
Creating new test account:
{
  lockScript: {
    codeHash: '0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8',
    hashType: 'type',
    args: '0xfbc386da8fd5e102d012d684239e2e8e0f183a14'
  },
  address: 'ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq0mcwrd4r74uypdqykkss3eut5wpuvr59qg378rq',
  pubKey: '0x022e338453f4645743a8945aaed96c7933b169522f87cb1c8c4d3a27d99f1a29d3',
  privKey: '0x3507a3957681f16395b25a379bf87321c62691b9fe8ede8906ab906a86bb2520'
}
✓
Funding test account
ResponseException [Error]: {"code":-4,"message":"RPCModuleIsDisabled: This RPC method is in the module `Indexer`. Please modify `rpc.modules` in ckb.toml and restart the ckb node to enable it."}
    at /home/exec/Projects/github.com/dckb-rescuer/v1-interface/node_modules/@ckb-lumos/rpc/src/method.ts:60:15
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async CkbIndexer.tip (/home/exec/Projects/github.com/dckb-rescuer/v1-interface/node_modules/@ckb-lumos/ckb-indexer/src/indexer.ts:80:12)
    at async CkbIndexer.waitForSync (/home/exec/Projects/github.com/dckb-rescuer/v1-interface/node_modules/@ckb-lumos/ckb-indexer/src/indexer.ts:93:42)
    at async TransactionBuilder.#collect (/home/exec/Projects/github.com/dckb-rescuer/v1-interface/domain_logic.ts:77:9)
    at async TransactionBuilder.fund (/home/exec/Projects/github.com/dckb-rescuer/v1-interface/domain_logic.ts:43:31)
    at async transferFrom (/home/exec/Projects/github.com/dckb-rescuer/v1-interface/utils.ts:201:31)
    at async main (/home/exec/Projects/github.com/dckb-rescuer/v1-interface/index.ts:26:31) {
  code: 204
}
```